### PR TITLE
Fix for the addition of fractions

### DIFF
--- a/Assets/Scripts/Cauldron/Cauldron.cs
+++ b/Assets/Scripts/Cauldron/Cauldron.cs
@@ -28,6 +28,9 @@ namespace FractionGame.Cauldron
                 return;
             }
 
+            // TODO: Add a check here to make sure that the fractions are of the same denominator
+            // (in other words, plants are the same type)
+
             ingredients.Add(ingredient);
             value += ingredient.Value;
 

--- a/Assets/Scripts/Utility/Fraction.cs
+++ b/Assets/Scripts/Utility/Fraction.cs
@@ -1,3 +1,4 @@
+using FractionGame.Inputs;
 using UnityEngine;
 
 namespace FractionGame.Utility
@@ -54,17 +55,42 @@ namespace FractionGame.Utility
         
         public static Fraction operator +(Fraction a, Fraction b)
         {
-            int numerator = a.numerator * b.denominator + b.numerator * a.denominator;
-            int denominator = a.denominator * b.denominator;
+            int denominator = CalculateCommonDenominator(a, b);
+            int numerator = denominator / a.denominator * a.numerator + denominator / b.denominator * b.numerator;
             return new Fraction(numerator, denominator);
         }
 
         public static Fraction operator -(Fraction a, Fraction b)
         {
-          int numerator = a.numerator * b.denominator - b.numerator * a.denominator;
-           int denominator = a.denominator * b.denominator;
-          return new Fraction(numerator, denominator);
+            int denominator = CalculateCommonDenominator(a, b);
+            int numerator = denominator / a.denominator * a.numerator - denominator / b.denominator * b.numerator;
+            return new Fraction(numerator, denominator);
         }
 
+        /// <summary>
+        /// Returns the common denominator between two Fractions.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static int CalculateCommonDenominator(Fraction a, Fraction b)
+        {
+            /* 
+             * Cases:
+             * 1) a and b are the same
+             * 2) one number is a factor of the other
+             * 3) the two numbers need to be multiplied together to get the common denominator
+             */
+
+            int x = a.denominator;
+            int y = b.denominator;
+
+            if (x == y || x % y == 0)
+                return x;
+            else if (y % x == 0)
+                return y;
+            else
+                return x * y;
+        }
     }
 }

--- a/Assets/Tests/Test Sprites/plant_dog.png.meta
+++ b/Assets/Tests/Test Sprites/plant_dog.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -85,6 +85,19 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 4
     buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/Assets/Tests/Test Sprites/roslinka.png.meta
+++ b/Assets/Tests/Test Sprites/roslinka.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -85,6 +85,19 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 4
     buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1


### PR DESCRIPTION
While not strictly necessary, having a get common denominator function might be useful, and this implementation works with fractions of the same denominator, so for now this will work. Later, because you shouldn't be allowed to add fractions of different denominators directly via the cauldron, we can add a check inside of the cauldron class in AddIngredient. That way, the ability to add fractions of different denominators is possible, just prevented because of how the rules of the game.